### PR TITLE
Updated link to Qube

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ hello! i am a first year computer science student at case western reserve univer
 
 - ### [matricie](https://github.com/rachel-tj/matricie)
   several linear algebra functions that help with matricies, such as taking the inverse of an nxn matrix or using rref.  there's also a truth table generator where you input a statement such as "(p^q) -> r" and it will print the truth table with p, q, r, and the aforementioned statement. 
-- ### [qube](https://github.com/rachel-tj/matricie)
+- ### [qube](https://github.com/rachel-tj/qube)
   an algorigthm that can solve a rubik's cube using dijikstra's algorithm, while printing the instructions.  the average runtime is around 0.4 seconds.  
 - ### [python madness](https://github.com/deadfishh/python-madness)
   in order to learn python, i redid the data structures assignments in python (linked list, stack, queue, hashtable graph), and wrote a base converter that can go anywhere between base 2 and 36.  


### PR DESCRIPTION
Link to qube was initially redirecting to Matricie